### PR TITLE
Update fsm.js

### DIFF
--- a/src/main/fsm.js
+++ b/src/main/fsm.js
@@ -397,3 +397,60 @@ function saveAsLaTeX() {
 	var texData = exporter.toLaTeX();
 	output(texData);
 }
+
+function writeToFile() {
+    var filename = "";
+    //don't accept empty file-name
+    while (filename === "") {
+        filename = prompt("Please provide a filename\nfor saving your graph:", "");
+    }
+
+    //unless user cancels, use cross-browser "download file" api
+    if (filename != null) {
+        filename += ".fsm"
+
+        //generate a link to a URI-encoded JSON-formated copy of current FSM
+        var generatedLink = document.createElement('a');
+        generatedLink.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(localStorage['fsm']));
+        generatedLink.setAttribute('download', filename);
+        //cross-browser activation of generated link
+        if (document.createEvent) {
+            var event = document.createEvent('MouseEvents');
+            event.initEvent('click', true, true);
+            generatedLink.dispatchEvent(event);
+        } else {
+            generatedLink.click();
+        }
+    }
+}
+
+function clearFSM() {
+    //reset internal fsm object and internal state, clear canvas
+    localStorage['fsm'] = '{"nodes":[],"links":[]}';
+    nodes = [];
+    links = [];
+    canvas.getContext('2d').clearRect(0, 0, canvas.width, canvas.height);
+}
+
+function loadFile() {
+    var file;
+    var reader = new FileReader();
+    var input = document.createElement('input');
+
+    input.type = 'file';
+    input.accept=".fsm";
+    //create event to read file as UTF-8 encoded into virtual local storage
+    input.onchange = e => {
+        var file = e.target.files[0];
+        reader.readAsText(file, 'UTF-8');
+        reader.onload = readerEvent => {
+            nodes = []
+            links = []
+            localStorage['fsm'] = readerEvent.target.result;
+            restoreBackup();
+            drawUsing(canvas.getContext('2d'));
+        }
+    }
+    //activate event
+    input.click();
+}

--- a/www/index.html
+++ b/www/index.html
@@ -102,7 +102,15 @@ if (typeof btoa == 'undefined') {
 		<span class="error">Your browser does not support<br>the HTML5 &lt;canvas&gt; element</span>
 	</canvas>
 	<div>
-		<p class="center">Export as: <a href="javascript:saveAsPNG()">PNG</a> | <a href="javascript:saveAsSVG()">SVG</a> | <a href="javascript:saveAsLaTeX()">LaTeX</a></p>
+		<p class="center">
+			Export as:
+			<a href="javascript:saveAsPNG()">PNG</a> |
+			<a href="javascript:saveAsSVG()">SVG</a> |
+			<a href="javascript:saveAsLaTeX()">LaTeX</a> |
+			<a href="javascript:writeToFile()">Save to File</a> |
+                        <a href="javascript:loadFile()">Load FSM</a> |
+                        <a href="javascript:clearFSM()">Clear FSM</a>
+		</p>
 		<textarea id="output"></textarea>
 		<p>The big white box above is the FSM designer.&nbsp; Here's how to use it:</p>
 		<ul>


### PR DESCRIPTION
Added 3 functions to fsm.js, mostly taking advantage of the existing way everything already works.
Added links to the 3 functions into index.html

ClearFSM:
    Clear the whole canvas without having to manually delete all nodes
writeToFile:
    Because the internal virtual filesystem structure holding the primary
    version of the FSM is already in JSON form, a link to an URI-encoded,
    UTF-8 formated version of that JSON is generated behind an invisible link,
    which is then auto-clicked.
    This engages the browser's own download process as if the user had clicked
    a link to a file, and therefore will be handled according to the user's browser
    settings.
loadFile:
    Assuming a user controlled file that was output by writeToFile,
    read file into internal virtual file system structure that already exists
    and use existing functionality to restore all other internal structures
    and then redraw the canvas accordingly.